### PR TITLE
Added option for number of processors to use.

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -8,7 +8,7 @@ import os
 import time
 from helpers import sequenceutils
 
-class Configs:
+class   Configs:
     
     workingDir = None
     sequencesPath = None
@@ -93,7 +93,12 @@ def buildConfigs(args):
                 Configs.backbonePaths.append(os.path.join(path, filename))
         else:
             Configs.backbonePaths.append(path)
-    
+
+    if args.numprocs > 0:
+        Configs.numCores = args.numprocs
+    else:
+        Configs.numCores = os.cpu_count()
+
     Configs.decompositionMaxSubsetSize = args.maxsubsetsize
     Configs.decompositionMaxNumSubsets = args.maxnumsubsets
     Configs.decompositionStrategy = args.decompstrategy
@@ -112,6 +117,6 @@ def buildConfigs(args):
     Configs.mclInflationFactor = args.inflationfactor
     
     Configs.logPath = os.path.join(Configs.workingDir, "log.txt")    
-    Configs.numCores = os.cpu_count()
+
 
        

--- a/gcm.py
+++ b/gcm.py
@@ -50,6 +50,10 @@ if __name__ == '__main__':
     parser.add_argument("-t", "--guidetree", type=str,
                         help="User guide tree for alignment",
                         required=False, default=None)
+
+    parser.add_argument("-np", "--numprocs", type=int,
+                        help="Number of processors to use (default: # cpus available)",
+                        required=False, default=-1)
     
     parser.add_argument("--maxsubsetsize", type=int,
                         help="Maximum subset size for divide-and-conquer",

--- a/helpers/treeutils.py
+++ b/helpers/treeutils.py
@@ -14,7 +14,7 @@ import random
 
 
 def loadTree(treePath, nameSpace=None):
-    tree = dendropy.Tree.get(path=treePath, schema="newick")
+    tree = dendropy.Tree.get(path=treePath, schema="newick", preserve_underscores=True)
     if nameSpace is None:
         nameSpace = tree.taxon_namespace
     else:
@@ -42,11 +42,13 @@ def compareTreesFromPath(treePath1, treePath2):
     tr1 = dendropy.Tree.get(path=treePath1,
                             schema='newick',
                             rooting='force-unrooted',
-                            taxon_namespace=tax)
+                            taxon_namespace=tax,
+                            preserve_underscores=True)
     tr2 = dendropy.Tree.get(path=treePath2,
                             schema='newick',
                             rooting='force-unrooted',
-                            taxon_namespace=tax)
+                            taxon_namespace=tax,
+                            preserve_underscores=True)
 
     tr1.collapse_basal_bifurcation(set_as_unrooted_tree=True)
     tr2.collapse_basal_bifurcation(set_as_unrooted_tree=True)


### PR DESCRIPTION
Title says it all. On intel machines in a lot of cases os.cpu_count() will yield the number of virtual cores, which is 2x the number of actual cores. Giving it all virtual cores to work with _can_ be a bit slower overall, so just added the option to set the processor count at the command line.