### PR TITLE
Resolved polytomies before guide tree decomposition.

### DIFF
--- a/magus_helpers/treeutils.py
+++ b/magus_helpers/treeutils.py
@@ -94,13 +94,13 @@ def compareDendropyTrees(tr1, tr2):
 def decomposeGuideTree(subsetsDir, sequencesPath, guideTreePath, maxSubsetSize, maxNumSubsets):
     sequences = sequenceutils.readFromFasta(sequencesPath, removeDashes = False)
     guideTree = dendropy.Tree.get(path=guideTreePath, schema="newick", preserve_underscores=True)
-    guideTree.collapse_basal_bifurcation()
     
     # resolve polytomies before decomposition
     # if not - large degree nodes can be issues when they contain
     # more than [maxsubsetsize] children, as the algorithm will only
     # be able to peel off one leaf at a time
     guideTree.resolve_polytomies(update_bipartitions=True)
+    guideTree.collapse_basal_bifurcation()
 
     for edge in guideTree.postorder_edge_iter():
         if len(edge.head_node.child_edges()) > 0:

--- a/magus_helpers/treeutils.py
+++ b/magus_helpers/treeutils.py
@@ -96,6 +96,12 @@ def decomposeGuideTree(subsetsDir, sequencesPath, guideTreePath, maxSubsetSize, 
     guideTree = dendropy.Tree.get(path=guideTreePath, schema="newick", preserve_underscores=True)
     guideTree.collapse_basal_bifurcation()
     
+    # resolve polytomies before decomposition
+    # if not - large degree nodes can be issues when they contain
+    # more than [maxsubsetsize] children, as the algorithm will only
+    # be able to peel off one leaf at a time
+    guideTree.resolve_polytomies(update_bipartitions=True)
+
     for edge in guideTree.postorder_edge_iter():
         if len(edge.head_node.child_edges()) > 0:
             edge.childs = sum([e.childs for e in edge.head_node.child_edges()])


### PR DESCRIPTION
Resolved polytomies before guide tree decomposition. Without this step, I have encountered issues with decomposing nodes that are high in degrees (e.g., >10,000). In that scenario, the decomposition can only peel off one leaf at a time, and this process will recursively create a lot of sub-alignments of size 1.