### PR TITLE
changed pypi worklow to ubuntu-latest

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9


### PR DESCRIPTION
Pypi publish run kept failing because of no available runner, found out that the workflow specifies to use a ubuntu-18.04 runner which is no longer available. Changed to ubuntu-latest.